### PR TITLE
Migrate Firestore access to the Admin SDK and ship default-deny rules

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,6 @@
+{
+  "firestore": {
+    "rules": "firestore.rules",
+    "indexes": "firestore.indexes.json"
+  }
+}

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,21 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "questions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "communityId", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "events",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "communityId", "order": "ASCENDING" },
+        { "fieldPath": "dateTime", "order": "DESCENDING" }
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,6 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /{document=**} { allow read, write: if false; }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "date-fns": "^3.6.0",
         "dotenv": "^16.5.0",
         "firebase": "^11.8.1",
+        "firebase-admin": "^13.10.0",
         "genkit": "^1.8.0",
         "lucide-react": "^0.475.0",
         "next": "15.3.3",
@@ -552,6 +553,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-3.2.0.tgz",
+      "integrity": "sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==",
+      "license": "MIT"
     },
     "node_modules/@firebase/ai": {
       "version": "1.3.0",
@@ -1360,7 +1367,7 @@
       "version": "7.11.0",
       "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-7.11.0.tgz",
       "integrity": "sha512-88uZ+jLsp1aVMj7gh3EKYH1aulTAMFAp8sH/v5a9w8q8iqSG27RiWLoxSAFr/XocZ9hGiWH1kEnBw+zl3xAgNA==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -1371,6 +1378,79 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/paginator": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-5.0.2.tgz",
+      "integrity": "sha512-DJS3s0OVH4zFDB1PzjxAsHqJT6sKVbRwwML0ZBP9PbU7Yebtu/7SWMRzvO2J3nUi9pRNITCfu4LJeooM2w4pjg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "arrify": "^2.0.0",
+        "extend": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/projectify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-4.0.0.tgz",
+      "integrity": "sha512-MmaX6HeSvyPbWGwFq7mXdo0uQZLGBYCwziiLIGq5JVX+/bdI3SAq6bP98trV5eTWfLuvsMcIC1YJOF2vfteLFA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/promisify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-4.0.0.tgz",
+      "integrity": "sha512-Orxzlfb9c67A15cq2JQEyVc7wEsmFBmHjZWZYQMUyJ1qivXyMwdyNOs9odi79hze+2zqdTtu1E19IM/FtqZ10g==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage": {
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.21.0.tgz",
+      "integrity": "sha512-l+IFTkd+6Y5LoAuXyYCKNAKtw/Ci+rAMqgdTB1jv4iZiLhw0rtq+0qjIRbBizXkNzEFmXiXUW0H7sZQQvk1ffA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@google-cloud/paginator": "^5.0.0",
+        "@google-cloud/projectify": "^4.0.0",
+        "@google-cloud/promisify": "<4.1.0",
+        "abort-controller": "^3.0.0",
+        "async-retry": "^1.3.3",
+        "duplexify": "^4.1.3",
+        "fast-xml-parser": "^5.3.4",
+        "gaxios": "^6.0.2",
+        "google-auth-library": "^9.6.3",
+        "html-entities": "^2.5.2",
+        "mime": "^3.0.0",
+        "p-limit": "^3.0.1",
+        "retry-request": "^7.0.0",
+        "teeny-request": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/@google/generative-ai": {
@@ -1990,6 +2070,19 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-3.0.0.tgz",
+      "integrity": "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -4211,7 +4304,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
       "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10"
@@ -4231,7 +4324,7 @@
       "version": "0.12.5",
       "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
       "integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/d3-array": {
@@ -4304,11 +4397,27 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "license": "MIT"
     },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/long": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
       "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
-      "dev": true,
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -4348,7 +4457,7 @@
       "version": "2.48.12",
       "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.12.tgz",
       "integrity": "sha512-G3sY+NpsA9jnwm0ixhAFQSJ3Q9JkpLZpJbI3GMv0mIAT0y3mRabYeINzal5WOChIiaTEGQYlHOKgkaM9EisWHw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/caseless": "*",
@@ -4361,7 +4470,7 @@
       "version": "2.5.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.3.tgz",
       "integrity": "sha512-XHIrMD0NpDrNM/Ckf7XJiBbLl57KEhT3+i3yY+eWm+cqYZJQTZrKo8Y8AWKnuV5GT4scfuUGt9LzNoIx3dU1nQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -4384,7 +4493,7 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/triple-beam": {
@@ -4413,7 +4522,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "event-target-shim": "^5.0.0"
@@ -4570,6 +4679,19 @@
         "node": ">= 8"
       }
     },
+    "node_modules/anynum": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/arg": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
@@ -4599,6 +4721,16 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
     },
+    "node_modules/arrify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/async": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
@@ -4615,11 +4747,21 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "retry": "0.13.1"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/at-least-node": {
@@ -4777,7 +4919,8 @@
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/bufrw": {
       "version": "1.4.0",
@@ -5212,7 +5355,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -5524,7 +5667,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -5652,7 +5795,7 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
       "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.4.1",
@@ -5705,7 +5848,7 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -5750,7 +5893,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -5856,7 +5999,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5976,6 +6119,15 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
     },
+    "node_modules/farmhash-modern": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/farmhash-modern/-/farmhash-modern-1.1.0.tgz",
+      "integrity": "sha512-6ypT4XfgqJk/F3Yuv4SX26I3doUjt0GTG4a+JgWxXQpxXzTBq8fPUeGHfcYMMDPHJHm3yPOSjaeBwBGAHWXCdA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -6031,6 +6183,47 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.3.0.tgz",
+      "integrity": "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "path-expression-matcher": "^1.6.2",
+        "xml-naming": "^0.3.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.10.1.tgz",
+      "integrity": "sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@nodable/entities": "^3.0.0",
+        "fast-xml-builder": "^1.2.0",
+        "is-unsafe": "^2.0.0",
+        "path-expression-matcher": "^1.6.2",
+        "strnum": "^2.4.1",
+        "xml-naming": "^0.3.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fastq": {
       "version": "1.19.0",
@@ -6177,6 +6370,83 @@
         "@firebase/storage": "0.13.12",
         "@firebase/storage-compat": "0.3.22",
         "@firebase/util": "1.12.0"
+      }
+    },
+    "node_modules/firebase-admin": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-13.10.0.tgz",
+      "integrity": "sha512-rbuCrJvYRwqBqvbccMS8fj/x2zsaMisdf5RQbRzQzr14Rbq9r2UlpuBHqWAwrO6c9dIRF56xF/xoepXsD5yDuQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@fastify/busboy": "^3.0.0",
+        "@firebase/database-compat": "^2.0.0",
+        "@firebase/database-types": "^1.0.6",
+        "farmhash-modern": "^1.1.0",
+        "fast-deep-equal": "^3.1.1",
+        "google-auth-library": "^10.6.1",
+        "jsonwebtoken": "^9.0.0",
+        "jwks-rsa": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@google-cloud/firestore": "^7.11.0",
+        "@google-cloud/storage": "^7.19.0"
+      }
+    },
+    "node_modules/firebase-admin/node_modules/gaxios": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.0.tgz",
+      "integrity": "sha512-RB5vLV+vvQeoFPCX4QMK6/hjVkbIamPp1QSUD0CiZcnj12qbpiL+pLbYtgD+oZkWl0tl9z+o2Utp+MpM3QRhBA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/firebase-admin/node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/firebase-admin/node_modules/google-auth-library": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.1.tgz",
+      "integrity": "sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/firebase-admin/node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/firebase/node_modules/@firebase/auth": {
@@ -6342,7 +6612,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/gaxios": {
@@ -6587,7 +6857,7 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-4.6.0.tgz",
       "integrity": "sha512-zKKLeLfcYBVOzzM48Brtn4EQkKcTli9w6c1ilzFK2NbJvcd4ATD8/XqFExImvE/W5IwMlKKwa5qqVufji3ioNQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.10.9",
@@ -6611,7 +6881,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -6632,7 +6902,7 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
       "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -6733,7 +7003,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -6773,6 +7043,23 @@
         "node": ">= 0.10.x"
       }
     },
+    "node_modules/html-entities": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+      "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -6799,7 +7086,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
       "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@tootallnate/once": "2",
@@ -6814,7 +7101,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "debug": "4"
@@ -6827,7 +7114,7 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
       "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -6845,7 +7132,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/https-proxy-agent": {
@@ -7208,6 +7495,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-unsafe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-2.0.0.tgz",
+      "integrity": "sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/is-wsl": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
@@ -7272,6 +7572,15 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "bin": {
         "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/jose": {
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {
@@ -7375,22 +7684,91 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/jwa": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
-      "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
       "dependencies": {
-        "buffer-equal-constant-time": "1.0.1",
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
         "safe-buffer": "^5.0.1"
       }
     },
-    "node_modules/jws": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
-      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+    "node_modules/jwks-rsa": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-3.2.2.tgz",
+      "integrity": "sha512-BqTyEDV+lS8F2trk3A+qJnxV5Q9EqKCBJOPti3W97r7qTympCZjb7h2X6f2kc+0K3rsSTY1/6YG2eaXKoj497w==",
+      "license": "MIT",
       "dependencies": {
-        "jwa": "^2.0.0",
+        "@types/jsonwebtoken": "^9.0.4",
+        "debug": "^4.3.4",
+        "jose": "^4.15.4",
+        "limiter": "^1.1.5",
+        "lru-memoizer": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/jwks-rsa/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jwks-rsa/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
     },
@@ -7419,6 +7797,11 @@
       "funding": {
         "url": "https://github.com/sponsors/antonk52"
       }
+    },
+    "node_modules/limiter": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
+      "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA=="
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
@@ -7453,10 +7836,58 @@
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
     },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/log-symbols": {
@@ -7521,6 +7952,28 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
+    },
+    "node_modules/lru-memoizer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-2.3.0.tgz",
+      "integrity": "sha512-GXn7gyHAMhO13WSKrIiNfztwxodVsP8IoZ3XfrJV4yH2x0/OeTO/FIaAHTY5YekdGgW94njfuKmyyt1E0mR6Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.clonedeep": "^4.5.0",
+        "lru-cache": "6.0.0"
+      }
+    },
+    "node_modules/lru-memoizer/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/lucide-react": {
       "version": "0.475.0",
@@ -8058,6 +8511,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -8131,6 +8600,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+      "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/path-is-absolute": {
@@ -8389,7 +8874,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-2.0.2.tgz",
       "integrity": "sha512-SAzp/O4Yh02jGdRc+uIrGoe87dkN/XtwxfZ4ZyafJHymd79ozp5VG5nyZ7ygqPM5+cpLDjjGnYFUkngonyDPOQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "protobufjs": "^7.2.5"
@@ -8688,7 +9173,7 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -8849,11 +9334,21 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/retry-request": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-7.0.2.tgz",
       "integrity": "sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/request": "^2.48.8",
@@ -9336,7 +9831,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
       "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "stubs": "^3.0.0"
@@ -9346,7 +9841,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
       "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/streamsearch": {
@@ -9361,7 +9856,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -9460,11 +9955,27 @@
         "node": ">=8"
       }
     },
+    "node_modules/strnum": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+      "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "anynum": "^1.0.1"
+      }
+    },
     "node_modules/stubs": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
       "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/styled-jsx": {
@@ -9589,7 +10100,7 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-9.0.0.tgz",
       "integrity": "sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "http-proxy-agent": "^5.0.0",
@@ -9606,7 +10117,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "debug": "4"
@@ -9619,7 +10130,7 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
       "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -9637,7 +10148,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "6",
@@ -9651,14 +10162,14 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/teeny-request/node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -9679,7 +10190,7 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
       "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -10274,6 +10785,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/xml-naming": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
+      "integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/xorshift": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/xorshift/-/xorshift-1.2.0.tgz",
@@ -10296,6 +10823,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
     },
     "node_modules/yaml": {
       "version": "2.7.0",
@@ -10378,6 +10911,19 @@
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "date-fns": "^3.6.0",
     "dotenv": "^16.5.0",
     "firebase": "^11.8.1",
+    "firebase-admin": "^13.10.0",
     "genkit": "^1.8.0",
     "lucide-react": "^0.475.0",
     "next": "15.3.3",

--- a/src/lib/firebase-admin.ts
+++ b/src/lib/firebase-admin.ts
@@ -1,0 +1,41 @@
+// Server-only Firebase Admin singleton. Never import this from client code —
+// it reads a privileged service-account credential and bypasses Firestore
+// security rules entirely. Only 'use server' modules under src/lib/services
+// should import from here.
+import { cert, getApps, initializeApp, type App } from 'firebase-admin/app';
+import { getFirestore, type Firestore } from 'firebase-admin/firestore';
+
+function loadAdminCredential() {
+  // Vercel (and any environment where shipping a key file isn't practical)
+  // sets the credential as an inline JSON string.
+  const serviceAccountJson = process.env.FIREBASE_SERVICE_ACCOUNT_JSON;
+  if (serviceAccountJson) {
+    return cert(JSON.parse(serviceAccountJson));
+  }
+
+  // Local development reads the credential from a file path instead.
+  const serviceAccountPath = process.env.FIREBASE_SERVICE_ACCOUNT_PATH;
+  if (serviceAccountPath) {
+    return cert(serviceAccountPath);
+  }
+
+  throw new Error(
+    'Firebase Admin credentials are not configured. Set FIREBASE_SERVICE_ACCOUNT_JSON ' +
+      '(inline service-account JSON, e.g. on Vercel) or FIREBASE_SERVICE_ACCOUNT_PATH ' +
+      '(path to a service-account JSON file, for local development). Neither may be ' +
+      'prefixed with NEXT_PUBLIC_ — this credential must never reach the browser.'
+  );
+}
+
+function getAdminApp(): App {
+  const existingApps = getApps();
+  if (existingApps.length > 0) {
+    return existingApps[0];
+  }
+
+  return initializeApp({
+    credential: loadAdminCredential(),
+  });
+}
+
+export const adminDb: Firestore = getFirestore(getAdminApp());

--- a/src/lib/services/commentService.ts
+++ b/src/lib/services/commentService.ts
@@ -1,7 +1,7 @@
 'use server';
 import type { Comment, UserProfile } from '@/lib/types';
-import { db } from '@/lib/firebase';
-import { collection, addDoc, getDocs, query, orderBy, serverTimestamp, Timestamp, where, doc, updateDoc } from 'firebase/firestore';
+import { adminDb } from '@/lib/firebase-admin';
+import { FieldValue, Timestamp } from 'firebase-admin/firestore';
 import { updateQuestionOnNewComment } from './questionService';
 
 interface CommentDataForFirestore extends Omit<Comment, 'id' | 'createdAt' | 'author'> {
@@ -16,12 +16,12 @@ export async function addComment(
   parentId?: string | null
 ): Promise<string> {
   try {
-    const docRef = await addDoc(collection(db, `questions/${questionId}/comments`), {
+    const docRef = await adminDb.collection(`questions/${questionId}/comments`).add({
       ...commentData,
       questionId,
       author,
       parentId: parentId || null,
-      createdAt: serverTimestamp(),
+      createdAt: FieldValue.serverTimestamp(),
       upvotes: 0,
       downvotes: 0,
     });
@@ -38,29 +38,29 @@ export async function addComment(
 
 export async function getCommentsForQuestion(questionId: string, sortBy: string = 'newest'): Promise<Comment[]> {
   try {
-    const commentsRef = collection(db, `questions/${questionId}/comments`);
+    const commentsRef = adminDb.collection(`questions/${questionId}/comments`);
     let q;
-    
+
     // Add sorting options
     switch (sortBy) {
       case 'oldest':
-        q = query(commentsRef, orderBy('createdAt', 'asc'));
+        q = commentsRef.orderBy('createdAt', 'asc');
         break;
       case 'top':
-        q = query(commentsRef, orderBy('upvotes', 'desc'));
+        q = commentsRef.orderBy('upvotes', 'desc');
         break;
       case 'controversial':
         // For controversial, we'll sort by most total votes (upvotes + downvotes)
         // Since Firestore doesn't support computed fields, we'll sort client-side
-        q = query(commentsRef, orderBy('createdAt', 'desc'));
+        q = commentsRef.orderBy('createdAt', 'desc');
         break;
       case 'newest':
       default:
-        q = query(commentsRef, orderBy('createdAt', 'desc'));
+        q = commentsRef.orderBy('createdAt', 'desc');
         break;
     }
-    
-    const querySnapshot = await getDocs(q);
+
+    const querySnapshot = await q.get();
     let comments = querySnapshot.docs.map(docSnap => {
       const data = docSnap.data();
       return {
@@ -106,10 +106,10 @@ export async function updateComment(
   userId: string
 ): Promise<void> {
   try {
-    const commentRef = doc(db, `questions/${questionId}/comments`, commentId);
-    await updateDoc(commentRef, {
+    const commentRef = adminDb.collection(`questions/${questionId}/comments`).doc(commentId);
+    await commentRef.update({
       content,
-      updatedAt: serverTimestamp(),
+      updatedAt: FieldValue.serverTimestamp(),
     });
   } catch (error) {
     console.error('Error updating comment: ', error);

--- a/src/lib/services/eventService.ts
+++ b/src/lib/services/eventService.ts
@@ -1,7 +1,7 @@
 'use server';
 import type { Event, UserProfile } from '@/lib/types';
-import { db } from '@/lib/firebase';
-import { collection, addDoc, getDocs, doc, getDoc, query, where, serverTimestamp, Timestamp } from 'firebase/firestore';
+import { adminDb } from '@/lib/firebase-admin';
+import { FieldValue, Timestamp } from 'firebase-admin/firestore';
 import { hasPermission } from '@/lib/utils/userUtils';
 
 // Type for event data going to Firestore, ensuring dateTime and createdAt are compatible
@@ -23,11 +23,11 @@ export async function addEvent(
   }
 
   try {
-    const docRef = await addDoc(collection(db, 'events'), {
+    const docRef = await adminDb.collection('events').add({
       ...eventData,
       author,
       dateTime: dateTime.toISOString(), // Store as ISO string
-      createdAt: serverTimestamp(), // Use Firestore server timestamp
+      createdAt: FieldValue.serverTimestamp(), // Use Firestore server timestamp
       rsvpCount: 0,
     });
     return docRef.id;
@@ -39,7 +39,7 @@ export async function addEvent(
 
 export async function getEvents(): Promise<Event[]> {
   try {
-    const querySnapshot = await getDocs(collection(db, 'events'));
+    const querySnapshot = await adminDb.collection('events').get();
     return querySnapshot.docs.map(docSnap => {
       const data = docSnap.data();
       return {
@@ -58,10 +58,10 @@ export async function getEvents(): Promise<Event[]> {
 
 export async function getEventById(eventId: string): Promise<Event | null> {
   try {
-    const docRef = doc(db, 'events', eventId);
-    const docSnap = await getDoc(docRef);
-    if (docSnap.exists()) {
-      const data = docSnap.data();
+    const docRef = adminDb.collection('events').doc(eventId);
+    const docSnap = await docRef.get();
+    if (docSnap.exists) {
+      const data = docSnap.data()!;
       return {
         ...data,
         id: docSnap.id,
@@ -78,8 +78,7 @@ export async function getEventById(eventId: string): Promise<Event | null> {
 
 export async function getEventsByCommunity(communityId: string): Promise<Event[]> {
   try {
-    const q = query(collection(db, 'events'), where('communityId', '==', communityId));
-    const querySnapshot = await getDocs(q);
+    const querySnapshot = await adminDb.collection('events').where('communityId', '==', communityId).get();
     return querySnapshot.docs.map(docSnap => {
       const data = docSnap.data();
       return {

--- a/src/lib/services/questionService.ts
+++ b/src/lib/services/questionService.ts
@@ -1,7 +1,7 @@
 'use server';
 import type { Question, UserProfile } from '@/lib/types';
-import { db } from '@/lib/firebase';
-import { collection, addDoc, getDocs, doc, getDoc, query, where, serverTimestamp, Timestamp, updateDoc, increment, deleteDoc } from 'firebase/firestore';
+import { adminDb } from '@/lib/firebase-admin';
+import { FieldValue, Timestamp } from 'firebase-admin/firestore';
 
 interface QuestionDataForFirestore extends Omit<Question, 'id' | 'createdAt' | 'author' | 'lastActivityAt'> {
   createdAt: Timestamp;
@@ -14,11 +14,11 @@ export async function addQuestion(
   author: UserProfile
 ): Promise<string> {
   try {
-    const docRef = await addDoc(collection(db, 'questions'), {
+    const docRef = await adminDb.collection('questions').add({
       ...questionData,
       author,
-      createdAt: serverTimestamp(),
-      lastActivityAt: serverTimestamp(),
+      createdAt: FieldValue.serverTimestamp(),
+      lastActivityAt: FieldValue.serverTimestamp(),
       upvotes: 0,
       downvotes: 0,
       views: 0,
@@ -33,7 +33,7 @@ export async function addQuestion(
 
 export async function getQuestions(): Promise<Question[]> {
   try {
-    const querySnapshot = await getDocs(collection(db, 'questions'));
+    const querySnapshot = await adminDb.collection('questions').get();
     return querySnapshot.docs.map(docSnap => {
       const data = docSnap.data();
       return {
@@ -51,14 +51,14 @@ export async function getQuestions(): Promise<Question[]> {
 
 export async function getQuestionById(questionId: string): Promise<Question | null> {
   try {
-    const docRef = doc(db, 'questions', questionId);
-    const docSnap = await getDoc(docRef);
-    if (docSnap.exists()) {
+    const docRef = adminDb.collection('questions').doc(questionId);
+    const docSnap = await docRef.get();
+    if (docSnap.exists) {
       // Increment views in database
-      await updateDoc(docRef, {
-          views: increment(1)
+      await docRef.update({
+          views: FieldValue.increment(1)
       });
-      const data = docSnap.data();
+      const data = docSnap.data()!;
       return {
         id: docSnap.id,
         ...data,
@@ -76,8 +76,7 @@ export async function getQuestionById(questionId: string): Promise<Question | nu
 
 export async function getQuestionsByCommunity(communityId: string): Promise<Question[]> {
   try {
-    const q = query(collection(db, 'questions'), where('communityId', '==', communityId));
-    const querySnapshot = await getDocs(q);
+    const querySnapshot = await adminDb.collection('questions').where('communityId', '==', communityId).get();
      return querySnapshot.docs.map(docSnap => {
       const data = docSnap.data();
       return {
@@ -103,10 +102,10 @@ export async function updateQuestion(
   userId: string
 ): Promise<void> {
   try {
-    const questionRef = doc(db, 'questions', questionId);
-    await updateDoc(questionRef, {
+    const questionRef = adminDb.collection('questions').doc(questionId);
+    await questionRef.update({
       ...updates,
-      updatedAt: serverTimestamp(),
+      updatedAt: FieldValue.serverTimestamp(),
     });
   } catch (error) {
     console.error('Error updating question: ', error);
@@ -117,10 +116,10 @@ export async function updateQuestion(
 // Function to update reply count and last activity
 export async function updateQuestionOnNewComment(questionId: string): Promise<void> {
   try {
-    const questionRef = doc(db, 'questions', questionId);
-    await updateDoc(questionRef, {
-      replyCount: increment(1),
-      lastActivityAt: serverTimestamp(),
+    const questionRef = adminDb.collection('questions').doc(questionId);
+    await questionRef.update({
+      replyCount: FieldValue.increment(1),
+      lastActivityAt: FieldValue.serverTimestamp(),
     });
   } catch (error) {
     console.error('Error updating question on new comment: ', error);
@@ -130,8 +129,8 @@ export async function updateQuestionOnNewComment(questionId: string): Promise<vo
 
 export async function deleteQuestion(questionId: string): Promise<void> {
   try {
-    const questionRef = doc(db, 'questions', questionId);
-    await deleteDoc(questionRef);
+    const questionRef = adminDb.collection('questions').doc(questionId);
+    await questionRef.delete();
   } catch (error) {
     console.error('Error deleting question: ', error);
     throw new Error('Failed to delete question.');

--- a/src/lib/services/searchService.ts
+++ b/src/lib/services/searchService.ts
@@ -1,5 +1,5 @@
-import { db } from '@/lib/firebase';
-import { collection, query, where, getDocs, orderBy, limit } from 'firebase/firestore';
+'use server';
+import { adminDb } from '@/lib/firebase-admin';
 import type { Question, Event } from '@/lib/types';
 import { COMMUNITIES } from '@/lib/constants';
 
@@ -76,14 +76,14 @@ export async function searchAll(
 
 async function searchQuestions(searchTerm: string, communityId?: string, maxResults: number = 12): Promise<SearchResult[]> {
   try {
-    const questionsRef = collection(db, 'questions');
-    let q = query(questionsRef, orderBy('createdAt', 'desc'), limit(50)); // Get more to filter locally
-    
+    const questionsRef = adminDb.collection('questions');
+    let q = questionsRef.orderBy('createdAt', 'desc').limit(50); // Get more to filter locally
+
     if (communityId) {
-      q = query(questionsRef, where('communityId', '==', communityId), orderBy('createdAt', 'desc'), limit(50));
+      q = questionsRef.where('communityId', '==', communityId).orderBy('createdAt', 'desc').limit(50);
     }
 
-    const querySnapshot = await getDocs(q);
+    const querySnapshot = await q.get();
     const questions: Question[] = [];
     
     querySnapshot.forEach((doc) => {
@@ -138,14 +138,14 @@ async function searchQuestions(searchTerm: string, communityId?: string, maxResu
 
 async function searchEvents(searchTerm: string, communityId?: string, maxResults: number = 6): Promise<SearchResult[]> {
   try {
-    const eventsRef = collection(db, 'events');
-    let q = query(eventsRef, orderBy('dateTime', 'desc'), limit(30));
-    
+    const eventsRef = adminDb.collection('events');
+    let q = eventsRef.orderBy('dateTime', 'desc').limit(30);
+
     if (communityId) {
-      q = query(eventsRef, where('communityId', '==', communityId), orderBy('dateTime', 'desc'), limit(30));
+      q = eventsRef.where('communityId', '==', communityId).orderBy('dateTime', 'desc').limit(30);
     }
 
-    const querySnapshot = await getDocs(q);
+    const querySnapshot = await q.get();
     const events: Event[] = [];
     
     querySnapshot.forEach((doc) => {

--- a/src/lib/services/userService.ts
+++ b/src/lib/services/userService.ts
@@ -1,24 +1,24 @@
 'use server';
 import type { UserProfile } from '@/lib/types';
-import { db } from '@/lib/firebase';
-import { doc, getDoc, setDoc, updateDoc, serverTimestamp, collection, query, where, getDocs } from 'firebase/firestore';
+import { adminDb } from '@/lib/firebase-admin';
+import { FieldValue } from 'firebase-admin/firestore';
 import { getPermissionsForRole } from '@/lib/utils/userUtils';
 
 export async function createUserProfile(user: UserProfile): Promise<void> {
   try {
-    const userRef = doc(db, 'users', user.uid);
-    const userDoc = await getDoc(userRef);
-    
-    if (!userDoc.exists()) {
-      await setDoc(userRef, {
+    const userRef = adminDb.collection('users').doc(user.uid);
+    const userDoc = await userRef.get();
+
+    if (!userDoc.exists) {
+      await userRef.set({
         uid: user.uid,
         email: user.email,
         displayName: user.displayName,
         photoURL: user.photoURL,
         role: 'user', // Default role
         permissions: ['read_forums', 'create_questions', 'vote'], // Default permissions
-        createdAt: serverTimestamp(),
-        updatedAt: serverTimestamp(),
+        createdAt: FieldValue.serverTimestamp(),
+        updatedAt: FieldValue.serverTimestamp(),
       });
     }
   } catch (error) {
@@ -29,11 +29,11 @@ export async function createUserProfile(user: UserProfile): Promise<void> {
 
 export async function getUserProfile(uid: string): Promise<UserProfile | null> {
   try {
-    const userRef = doc(db, 'users', uid);
-    const userDoc = await getDoc(userRef);
-    
-    if (userDoc.exists()) {
-      const data = userDoc.data();
+    const userRef = adminDb.collection('users').doc(uid);
+    const userDoc = await userRef.get();
+
+    if (userDoc.exists) {
+      const data = userDoc.data()!;
       return {
         uid: data.uid,
         email: data.email,
@@ -54,10 +54,8 @@ export async function getUserProfile(uid: string): Promise<UserProfile | null> {
 
 export async function searchUserByEmail(email: string): Promise<UserProfile | null> {
   try {
-    const usersRef = collection(db, 'users');
-    const q = query(usersRef, where('email', '==', email));
-    const querySnapshot = await getDocs(q);
-    
+    const querySnapshot = await adminDb.collection('users').where('email', '==', email).get();
+
     if (!querySnapshot.empty) {
       const docSnap = querySnapshot.docs[0];
       const data = docSnap.data();
@@ -113,13 +111,13 @@ export async function searchUser(searchTerm: string): Promise<UserProfile | null
 
 export async function updateUserRole(uid: string, role: 'user' | 'moderator' | 'admin'): Promise<void> {
   try {
-    const userRef = doc(db, 'users', uid);
+    const userRef = adminDb.collection('users').doc(uid);
     const permissions = getPermissionsForRole(role);
-    
-    await updateDoc(userRef, {
+
+    await userRef.update({
       role,
       permissions,
-      updatedAt: serverTimestamp(),
+      updatedAt: FieldValue.serverTimestamp(),
     });
   } catch (error) {
     console.error('Error updating user role:', error);
@@ -130,9 +128,8 @@ export async function updateUserRole(uid: string, role: 'user' | 'moderator' | '
 // Debug function to list all users
 export async function getAllUsers(): Promise<UserProfile[]> {
   try {
-    const usersRef = collection(db, 'users');
-    const querySnapshot = await getDocs(usersRef);
-    
+    const querySnapshot = await adminDb.collection('users').get();
+
     const users = querySnapshot.docs.map(docSnap => {
       const data = docSnap.data();
       return {

--- a/src/lib/services/voteService.ts
+++ b/src/lib/services/voteService.ts
@@ -1,6 +1,6 @@
 'use server';
-import { db } from '@/lib/firebase';
-import { doc, updateDoc, increment, getDoc, setDoc } from 'firebase/firestore';
+import { adminDb } from '@/lib/firebase-admin';
+import { FieldValue } from 'firebase-admin/firestore';
 
 export interface VoteData {
   questionId?: string;
@@ -11,41 +11,41 @@ export interface VoteData {
 
 export async function voteOnQuestion(questionId: string, userId: string, voteType: 'up' | 'down' | 'none'): Promise<void> {
   try {
-    const voteRef = doc(db, `votes/questions/${questionId}/${userId}`);
-    const questionRef = doc(db, 'questions', questionId);
-    
+    const voteRef = adminDb.doc(`votes/questions/${questionId}/${userId}`);
+    const questionRef = adminDb.collection('questions').doc(questionId);
+
     // Get existing vote
-    const existingVote = await getDoc(voteRef);
-    const currentVote = existingVote.exists() ? existingVote.data()?.voteType : 'none';
-    
+    const existingVote = await voteRef.get();
+    const currentVote = existingVote.exists ? existingVote.data()?.voteType : 'none';
+
     if (currentVote === voteType) {
       return; // No change needed
     }
-    
+
     // Update vote record
     if (voteType === 'none') {
-      await setDoc(voteRef, { voteType: 'none', updatedAt: new Date() });
+      await voteRef.set({ voteType: 'none', updatedAt: new Date() });
     } else {
-      await setDoc(voteRef, { voteType, updatedAt: new Date() });
+      await voteRef.set({ voteType, updatedAt: new Date() });
     }
-    
+
     // Calculate vote changes
     let upvoteChange = 0;
     let downvoteChange = 0;
-    
+
     if (currentVote === 'up') upvoteChange = -1;
     if (currentVote === 'down') downvoteChange = -1;
-    
+
     if (voteType === 'up') upvoteChange += 1;
     if (voteType === 'down') downvoteChange += 1;
-    
+
     // Update question vote counts
     const updateData: any = {};
-    if (upvoteChange !== 0) updateData.upvotes = increment(upvoteChange);
-    if (downvoteChange !== 0) updateData.downvotes = increment(downvoteChange);
-    
+    if (upvoteChange !== 0) updateData.upvotes = FieldValue.increment(upvoteChange);
+    if (downvoteChange !== 0) updateData.downvotes = FieldValue.increment(downvoteChange);
+
     if (Object.keys(updateData).length > 0) {
-      await updateDoc(questionRef, updateData);
+      await questionRef.update(updateData);
     }
   } catch (error) {
     console.error('Error voting on question:', error);
@@ -55,41 +55,41 @@ export async function voteOnQuestion(questionId: string, userId: string, voteTyp
 
 export async function voteOnComment(questionId: string, commentId: string, userId: string, voteType: 'up' | 'down' | 'none'): Promise<void> {
   try {
-    const voteRef = doc(db, `votes/comments/${commentId}/${userId}`);
-    const commentRef = doc(db, `questions/${questionId}/comments`, commentId);
-    
+    const voteRef = adminDb.doc(`votes/comments/${commentId}/${userId}`);
+    const commentRef = adminDb.collection(`questions/${questionId}/comments`).doc(commentId);
+
     // Get existing vote
-    const existingVote = await getDoc(voteRef);
-    const currentVote = existingVote.exists() ? existingVote.data()?.voteType : 'none';
-    
+    const existingVote = await voteRef.get();
+    const currentVote = existingVote.exists ? existingVote.data()?.voteType : 'none';
+
     if (currentVote === voteType) {
       return; // No change needed
     }
-    
+
     // Update vote record
     if (voteType === 'none') {
-      await setDoc(voteRef, { voteType: 'none', updatedAt: new Date() });
+      await voteRef.set({ voteType: 'none', updatedAt: new Date() });
     } else {
-      await setDoc(voteRef, { voteType, updatedAt: new Date() });
+      await voteRef.set({ voteType, updatedAt: new Date() });
     }
-    
+
     // Calculate vote changes
     let upvoteChange = 0;
     let downvoteChange = 0;
-    
+
     if (currentVote === 'up') upvoteChange = -1;
     if (currentVote === 'down') downvoteChange = -1;
-    
+
     if (voteType === 'up') upvoteChange += 1;
     if (voteType === 'down') downvoteChange += 1;
-    
+
     // Update comment vote counts
     const updateData: any = {};
-    if (upvoteChange !== 0) updateData.upvotes = increment(upvoteChange);
-    if (downvoteChange !== 0) updateData.downvotes = increment(downvoteChange);
-    
+    if (upvoteChange !== 0) updateData.upvotes = FieldValue.increment(upvoteChange);
+    if (downvoteChange !== 0) updateData.downvotes = FieldValue.increment(downvoteChange);
+
     if (Object.keys(updateData).length > 0) {
-      await updateDoc(commentRef, updateData);
+      await commentRef.update(updateData);
     }
   } catch (error) {
     console.error('Error voting on comment:', error);
@@ -99,10 +99,10 @@ export async function voteOnComment(questionId: string, commentId: string, userI
 
 export async function getUserVote(itemId: string, userId: string, itemType: 'question' | 'comment'): Promise<'up' | 'down' | 'none'> {
   try {
-    const voteRef = doc(db, `votes/${itemType}s/${itemId}/${userId}`);
-    const voteDoc = await getDoc(voteRef);
-    
-    if (voteDoc.exists()) {
+    const voteRef = adminDb.doc(`votes/${itemType}s/${itemId}/${userId}`);
+    const voteDoc = await voteRef.get();
+
+    if (voteDoc.exists) {
       return voteDoc.data()?.voteType || 'none';
     }
     return 'none';


### PR DESCRIPTION
Fixes #16
Fixes #28

## Why

The database was world-readable and world-writable. The deployed rules were still the test-mode default:

```
match /{document=**} {
  allow read, write: if request.time < timestamp.date(2026, 10, 10);
}
```

Two separate problems with that. First, anyone on the internet could read and write every document using only the `NEXT_PUBLIC_FIREBASE_*` config, which ships in the client bundle by design. Second, that rule **expires on 2026-10-10** — after which every client request is denied, and because all data access went through the client SDK, the app would have stopped working entirely.

The rules could not simply be tightened, though. All five `'use server'` service modules imported the Firebase **client** SDK, so server-side writes arrived with `request.auth == null`. Any rule strict enough to block an anonymous attacker was also strict enough to block the application itself. That is why this had to be an SDK migration rather than a rules change.

## What changed

**New `src/lib/firebase-admin.ts`** — a server-only Admin Firestore singleton. Credentials come from `FIREBASE_SERVICE_ACCOUNT_JSON` (inline, checked first) or `FIREBASE_SERVICE_ACCOUNT_PATH` (local file), never from a `NEXT_PUBLIC_` variable. Re-initialisation is guarded with `getApps().length`.

It deliberately does *not* carry `'use server'`: Next.js only permits async-function exports from such files, and this module exports a `Firestore` instance.

**All six service modules migrated** from the client SDK to Admin — `questionService`, `commentService`, `eventService`, `userService`, `voteService`, `searchService`. The Admin API differs throughout (`db.collection(...)` chaining, `.get()`, `FieldValue.serverTimestamp()`, `doc.exists` as a property rather than a method), so every call site changed.

**`searchService.ts` gained `'use server'`** (#28). It was the one module querying Firestore straight from the browser, so it had to move server-side before rules could deny client access outright.

**`firestore.rules`, `firestore.indexes.json`, `firebase.json` added** so the enforcement boundary and the index definitions live in version control and deploy from the repository instead of existing only in the console.

**Two missing composite indexes** are now defined and deployed: `questions` (`communityId` ASC, `createdAt` DESC) and `events` (`communityId` ASC, `dateTime` DESC). Both were absent, so community-filtered search and events were throwing `failed-precondition` — and because the services swallow errors and return `[]`, they were failing *silently* as empty results.

## Verification

The load-bearing evidence is a before/after probe using an anonymous client with only the public config and no sign-in:

| Collection | Before | After |
|---|---|---|
| `questions` | 8 docs returned | `permission-denied` |
| `events` | 3 docs returned | `permission-denied` |
| `users` | 10 docs returned | `permission-denied` |
| `comments` | readable | `permission-denied` |
| `votes` | readable | `permission-denied` |

Before this change those reads succeeded, which confirmed the exposure was real rather than inferred from the rule text. They now fail. Meanwhile the same reads through the Admin SDK still return 8/3/10, because the Admin SDK bypasses rules by design — so the application keeps working while external access is closed.

Also checked:

- `npm run build` succeeds.
- `npx tsc --noEmit` reports **exactly 7 errors, identical to the pre-change baseline** — 2 in `community/[communityId]/page.tsx`, 4 in `SettingsContent.tsx`, 1 in `searchService.ts`. No new type errors. (Those 7 are tracked in #47; `next.config.ts` currently sets `ignoreBuildErrors`, so a green build alone would not have proven this.)
- Dev server boots and serves 200 on `/`, `/qna`, `/events`, `/search`, both before and after the rules deploy.
- Both indexes polled until they left `BUILDING` and the real query shapes stopped returning `failed-precondition` — "deploy succeeded" alone is not sufficient for indexes.
- No `.env` file, service-account key, or private key is committed.

## Deployment note

Any hosted environment needs **`FIREBASE_SERVICE_ACCOUNT_JSON`** set to the full service-account JSON as a single inline string, with no `NEXT_PUBLIC_` prefix. The file-path variant is local-only.

## Explicitly out of scope

The diff is deliberately narrow — an SDK swap plus the directive, with no behavioural changes — so it can be reviewed as one mechanical transformation. Left untouched on purpose:

- Caller authorization. Server actions still trust their arguments, so #17, #19, #21, #22, and #30 remain open. This PR is their prerequisite: it establishes a trustworthy server-side identity to check against, but does not yet perform the checks.
- Vote atomicity (#29), the view-count write-on-read (#33), unbounded reads, and error swallowing (#37).
- Author data minimisation in search results (#23) — the full author profile including `email` is still projected into search output. #28's suggested fix mentions this; it is not addressed here.
- The pre-existing `Event.createdAt` type gap (#48) and its `as unknown as Event` casts.
